### PR TITLE
Pause non-commercial docs

### DIFF
--- a/scripts/build_readme_and_index_html.py
+++ b/scripts/build_readme_and_index_html.py
@@ -204,4 +204,5 @@ def deploy_noncommercial_data():
 
 if __name__ == "__main__":
     deploy_open_data()
-    deploy_noncommercial_data()
+#     Temporarily pause non-commercial doc generation 
+#     deploy_noncommercial_data()


### PR DESCRIPTION
Temporarily pause non-commercial documentation generation in order to deploy covid-response docs.
Required because pending new SAS token for non-commercial is holding up covid-response deployment